### PR TITLE
GCS-setup fails with user/pass stored in file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -106,7 +106,7 @@ class globus_connect_server::config (
   exec { 'globus-connect-server-setup':
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',
     command     => 'globus-connect-server-setup < /root/globus-connect-server-setup.rsp',
-    environment => [ "HOME=${::root_home}"
+    environment => [ "HOME=${::root_home}",
                    "GLOBUS_USER=${::globus_connect_server::params::gcs_globus_user}",
                    "GLOBUS_PASSWORD=${::globus_connect_server::params::gcs_globus_password}",
                    ],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -105,7 +105,7 @@ class globus_connect_server::config (
 
   exec { 'globus-connect-server-setup':
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',
-    command     => 'globus-connect-server-setup < /root/globus-connect-server-setup.rsp',
+    command     => 'globus-connect-server-setup',
     environment => [ "HOME=${::root_home}",
                    "GLOBUS_USER=${::globus_connect_server::params::gcs_globus_user}",
                    "GLOBUS_PASSWORD=${::globus_connect_server::params::gcs_globus_password}",

--- a/templates/globus-connect-server-setup.rsp.erb
+++ b/templates/globus-connect-server-setup.rsp.erb
@@ -1,2 +1,0 @@
-<%= scope['globus_connect_server::config::gcs_globus_user'] %>
-<%= scope['globus_connect_server::config::gcs_globus_password'] %>


### PR DESCRIPTION
In file `manifests/config.pp`, the command `globus-connect-server-setup < /root/globus-connect-server-setup.rsp` fails with an error that it can't get username and password.

A suggested fix is to put the username and password in environment variables:

>   exec { 'globus-connect-server-setup':
    path        => '/bin:/usr/bin:/sbin:/usr/sbin',
    command     => 'globus-connect-server-setup',
    environment => [ "HOME=${::root_home}",
                     "GLOBUS_USER=${::globus_connect_server::params::gcs_globus_user}",
                     "GLOBUS_PASSWORD=${::globus_connect_server::params::gcs_globus_password}",
                   ],
    refreshonly => true,
  }


This has the added benefit that the username/password are never stored on the system.  The config file can use the hardcoded settings `'%(GLOBUS_PASSWORD)s'` and `'%(GLOBUS_USER)s'`.  And the file `/root/globus-connect-server-setup.rsp` isn't needed at all.
